### PR TITLE
Do not try to compile header files in build.rs

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -17,6 +17,11 @@ fn main() {
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 
+    println!("cargo:rerun-if-changed={}", src_dir.join("preamble.h").to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", src_dir.join("state.h").to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", src_dir.join("indent_vec.h").to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", src_dir.join("scanner.h").to_str().unwrap());
+
     track_file(&mut c_config, &src_dir.join("scanner.c"));
 
     let parser_path = src_dir.join("parser.c");

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -17,10 +17,6 @@ fn main() {
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 
-    track_file(&mut c_config, &src_dir.join("preamble.h"));
-    track_file(&mut c_config, &src_dir.join("state.h"));
-    track_file(&mut c_config, &src_dir.join("indent_vec.h"));
-    track_file(&mut c_config, &src_dir.join("scanner.h"));
     track_file(&mut c_config, &src_dir.join("scanner.c"));
 
     let parser_path = src_dir.join("parser.c");


### PR DESCRIPTION
Compiling tracked header files in build.rs is causing linker errors on MacOs.