### PR TITLE
Fixes

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -15,7 +15,7 @@ const sub = ($, rule) => seq(
 );
 
 const block = ($, rule) =>
-      sub($, repeat1(seq(rule, $.vsemi)));
+  sub($, repeat1(seq(rule, optional($.line_comment), $.vsemi)));
 
 const maybe_block = ($, rule) => choice(
   rule,
@@ -158,9 +158,6 @@ module.exports = grammar({
   extras: $ => [
     /[\n\r ]+/,
     $._synchronize,
-    $.line_comment,
-    $.block_comment,
-    $.doc_comment,
   ],
 
 
@@ -336,6 +333,8 @@ module.exports = grammar({
     module: $ => repeat1(seq(field("decl", $._decl), $.vsemi)),
 
     _decl: $ => choice(
+      $.line_comment,
+      $.block_comment,
       $.pragma,
       $.include,
       $.using,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -31,7 +31,7 @@
 
 (expr_variable) @variable.expr
 (((expr_variable) @expr.state)
- (#match @expr.state "state")
+ (#match? @expr.state "state")
  )
 (expr_application fun: (expr_variable) @variable.expr.function)
 (member_assign old_value: (identifier) @variable.map_old_value)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "aesophia",
   "word": "_lex_low_id",
   "rules": {
@@ -414,6 +415,14 @@
     "_decl": {
       "type": "CHOICE",
       "members": [
+        {
+          "type": "SYMBOL",
+          "name": "line_comment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "block_comment"
+        },
         {
           "type": "SYMBOL",
           "name": "pragma"
@@ -856,6 +865,18 @@
                                 }
                               },
                               {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "line_comment"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
                                 "type": "SYMBOL",
                                 "name": "vsemi"
                               }
@@ -1083,6 +1104,18 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "line_comment"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
                       },
                       {
                         "type": "SYMBOL",
@@ -1802,6 +1835,18 @@
                   "type": "SYMBOL",
                   "name": "_expression"
                 }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "line_comment"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               },
               {
                 "type": "SYMBOL",
@@ -3547,6 +3592,18 @@
                       "type": "SYMBOL",
                       "name": "switch_case"
                     }
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "line_comment"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
                   },
                   {
                     "type": "SYMBOL",
@@ -6586,18 +6643,6 @@
     {
       "type": "SYMBOL",
       "name": "_synchronize"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "line_comment"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "block_comment"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "doc_comment"
     }
   ],
   "conflicts": [
@@ -6901,5 +6946,6 @@
     "_operator",
     "_literal",
     "_type"
-  ]
+  ],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -26,7 +26,15 @@
         "named": true
       },
       {
+        "type": "block_comment",
+        "named": true
+      },
+      {
         "type": "include",
+        "named": true
+      },
+      {
+        "type": "line_comment",
         "named": true
       },
       {
@@ -516,21 +524,6 @@
     }
   },
   {
-    "type": "doc_comment",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "doc_comment",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "expr_application",
     "named": true,
     "fields": {
@@ -618,6 +611,10 @@
       "required": true,
       "types": [
         {
+          "type": "line_comment",
+          "named": true
+        },
+        {
           "type": "vclose",
           "named": true
         },
@@ -693,6 +690,11 @@
         }
       ]
     }
+  },
+  {
+    "type": "expr_hole",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "expr_if",
@@ -1317,6 +1319,10 @@
       "required": false,
       "types": [
         {
+          "type": "line_comment",
+          "named": true
+        },
+        {
           "type": "vclose",
           "named": true
         },
@@ -1860,6 +1866,11 @@
     }
   },
   {
+    "type": "pat_hole",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "pat_list",
     "named": true,
     "fields": {
@@ -2345,6 +2356,10 @@
           "named": true
         },
         {
+          "type": "line_comment",
+          "named": true
+        },
+        {
           "type": "vclose",
           "named": true
         },
@@ -2367,6 +2382,7 @@
   {
     "type": "source",
     "named": true,
+    "root": true,
     "fields": {
       "content": {
         "multiple": false,
@@ -2469,6 +2485,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "line_comment",
+          "named": true
+        },
         {
           "type": "vclose",
           "named": true
@@ -3049,6 +3069,10 @@
     "named": false
   },
   {
+    "type": "*/",
+    "named": false
+  },
+  {
     "type": ",",
     "named": false
   },
@@ -3058,6 +3082,14 @@
   },
   {
     "type": "..",
+    "named": false
+  },
+  {
+    "type": "/*",
+    "named": false
+  },
+  {
+    "type": "//",
     "named": false
   },
   {
@@ -3078,6 +3110,10 @@
   },
   {
     "type": "=>",
+    "named": false
+  },
+  {
+    "type": "???",
     "named": false
   },
   {
@@ -3121,6 +3157,10 @@
     "named": false
   },
   {
+    "type": "_",
+    "named": false
+  },
+  {
     "type": "as",
     "named": false
   },
@@ -3159,10 +3199,6 @@
   {
     "type": "entrypoint",
     "named": false
-  },
-  {
-    "type": "expr_hole",
-    "named": true
   },
   {
     "type": "false",
@@ -3306,10 +3342,6 @@
   },
   {
     "type": "op_sub",
-    "named": true
-  },
-  {
-    "type": "pat_hole",
     "named": true
   },
   {

--- a/src/tree_sitter/alloc.h
+++ b/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -278,7 +279,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,12 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +32,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -47,6 +54,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {
@@ -78,6 +86,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -92,7 +106,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -108,13 +122,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -128,15 +142,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -144,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "aesophia",
+      "camelcase": "AESophia",
+      "scope": "source.aesophia",
+      "file-types": [
+        "aes"
+      ],
+      "injection-regex": "^aesophia$",
+      "class-name": "TreeSitterAESophia",
+      "highlights": "queries/highlights.scm",
+      "locals": "queries/locals.scm",
+      "tags": "queries/tags.scm"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "AESophia Lang",
+    "authors": [
+      {
+        "name": "aeternity",
+        "email": "developers@aeternity.com"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/aeternity/tree-sitter-aesophia",
+      "homepage": "https://docs.aeternity.com/developer-documentation/aesophia"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true,
+    "zig": false
+  }
+}


### PR DESCRIPTION
some misc things that i needed to do to get this working for myself in neovim.

- use proper match? predicate for tree sitter highlighting
- allow line comments on the end of lines to parse without error
- include comments as decls so they're navigable and register as their own nodes in the tree
- add a basic tree-sitter json config

been using this config for a few weeks. there are still some tweaks i plan on making but it's much more usable for me now.