### PR TITLE
Merge lit_address and lit_signature in one rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1106,7 +1106,6 @@ module.exports = grammar({
       $.lit_constructor,
       $.lit_bytes,
       $.lit_address,
-      $.lit_signature,
       $.lit_lambda_op,
       $.lit_integer,
       $.lit_bool,
@@ -1119,7 +1118,6 @@ module.exports = grammar({
     lit_bytes: $ => $._lex_bytes,
 
     lit_address: $ => $._lex_address,
-    lit_signature: $ => $._lex_signature,
 
     lit_lambda_op: $ => parens($, field("op", $._operator)),
 
@@ -1282,11 +1280,7 @@ module.exports = grammar({
     // This has to be above _lex_low_id in order to take priority. Somehow precedences don't work
     // here...
     _lex_address: $ => token(seq(
-      choice('ak', 'ok', 'oq', 'ct'),
-      /_[0-9a-zA-Z]+/,
-    )),
-    _lex_signature: $ => token(seq(
-      'sg',
+      choice('ak', 'ok', 'oq', 'ct', 'sg'),
       /_[0-9a-zA-Z]+/,
     )),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5700,10 +5700,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "lit_signature"
-        },
-        {
-          "type": "SYMBOL",
           "name": "lit_lambda_op"
         },
         {
@@ -5735,10 +5731,6 @@
     "lit_address": {
       "type": "SYMBOL",
       "name": "_lex_address"
-    },
-    "lit_signature": {
-      "type": "SYMBOL",
-      "name": "_lex_signature"
     },
     "lit_lambda_op": {
       "type": "SEQ",
@@ -6499,24 +6491,12 @@
               {
                 "type": "STRING",
                 "value": "ct"
+              },
+              {
+                "type": "STRING",
+                "value": "sg"
               }
             ]
-          },
-          {
-            "type": "PATTERN",
-            "value": "_[0-9a-zA-Z]+"
-          }
-        ]
-      }
-    },
-    "_lex_signature": {
-      "type": "TOKEN",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "sg"
           },
           {
             "type": "PATTERN",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -200,10 +200,6 @@
         "named": true
       },
       {
-        "type": "lit_signature",
-        "named": true
-      },
-      {
         "type": "lit_string",
         "named": true
       }
@@ -1637,11 +1633,6 @@
         ]
       }
     }
-  },
-  {
-    "type": "lit_signature",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "lit_string",


### PR DESCRIPTION
The two rules are identical, except for the prefix part. The rules are also handled exactly the same way during the conversion to AST.